### PR TITLE
fix wrong input ::floor

### DIFF
--- a/libvis/src/libvis/cuda/pixel_corner_projector.cuh
+++ b/libvis/src/libvis/cuda/pixel_corner_projector.cuh
@@ -145,10 +145,10 @@ struct PixelCornerProjector_ {
     float2 undistorted_nxy = make_float2(position.x / position.z,
                                          position.y / position.z);
     
-    double fc = (undistorted_nxy.x - min_nx) * ((resolution_x - 1) / (max_nx - min_nx));
-    double fr = (undistorted_nxy.y - min_ny) * ((resolution_y - 1) / (max_ny - min_ny));
-    const int row = ::floor(fr);
-    const int col = ::floor(fc);
+    float fc = (undistorted_nxy.x - min_nx) * ((resolution_x - 1) / (max_nx - min_nx));
+    float fr = (undistorted_nxy.y - min_ny) * ((resolution_y - 1) / (max_ny - min_ny));
+    const int row = ::floorf(fr);
+    const int col = ::floorf(fc);
     float r_frac = fr - row;
     float c_frac = fc - col;
     

--- a/libvis/src/libvis/cuda/pixel_corner_projector.cuh
+++ b/libvis/src/libvis/cuda/pixel_corner_projector.cuh
@@ -145,8 +145,8 @@ struct PixelCornerProjector_ {
     float2 undistorted_nxy = make_float2(position.x / position.z,
                                          position.y / position.z);
     
-    float fc = (undistorted_nxy.x - min_nx) * ((resolution_x - 1) / (max_nx - min_nx));
-    float fr = (undistorted_nxy.y - min_ny) * ((resolution_y - 1) / (max_ny - min_ny));
+    double fc = (undistorted_nxy.x - min_nx) * ((resolution_x - 1) / (max_nx - min_nx));
+    double fr = (undistorted_nxy.y - min_ny) * ((resolution_y - 1) / (max_ny - min_ny));
     const int row = ::floor(fr);
     const int col = ::floor(fc);
     float r_frac = fr - row;


### PR DESCRIPTION
fixing ::floor backward mechanism.  in cuda 10.2 and msvc2019 compiler complain about calling host function from device, reason is cuda floor function as input accept double type, and this cause compiler try to use std floor.